### PR TITLE
optimize ticket description/pricing styles

### DIFF
--- a/styles/tito.scss
+++ b/styles/tito.scss
@@ -7,16 +7,28 @@
 }
 
 .tito-ticket.row {
+  display: flex !important;
+  flex-direction: row !important;
+  justify-content: space-between !important;
   margin: 0 !important;
   border-bottom-color: #efefef !important;
 }
 
 .tito-ticket-name-wrapper {
-  width: 80%;
+  width: 75%;
 }
 
 .tito-ticket-price-quantity-wrapper {
   width: 20%;
+}
+
+.tito-ticket-price-quantity {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  width: 100%;
 }
 
 .tito-previous .tito-ticket-name-wrapper {
@@ -34,7 +46,7 @@
 }
 
 .tito-submit {
-  padding: .5em 2em !important;
+  padding: 0.5em 2em !important;
   font-family: $fh;
   font-size: 1em !important;
   background-color: $color-accent !important;


### PR DESCRIPTION
this pr especially aims to optimize mobile appearance of the tickets section.

here's what I attempt to improve primarily using flexbox instead of floats:
<img width="841" alt="react_fi_tickets_old_new_mobile" src="https://user-images.githubusercontent.com/4241744/35616462-95668c80-0675-11e8-9bf9-0a01ada23820.png">

note: all used ```!important``` flags were added due to not being overwritten by tito-tickets default styles being injected when the ticket widget is loaded.