### PR TITLE
fix: Styles of logo widths not to be over 100% of container

### DIFF
--- a/styles/sponsors.scss
+++ b/styles/sponsors.scss
@@ -36,7 +36,7 @@
     .sponsors--heading {
       color: #e79a00;
     }
-    .sponsors--logo {
+    .sponsors--item {
       max-width: 380px;
     }
   }
@@ -44,7 +44,7 @@
     .sponsors--heading {
       color: #8f8f8f;
     }
-    .sponsors--logo {
+    .sponsors--item {
       max-width: 200px;
     }
   }


### PR DESCRIPTION
fix: Styles of logo widths not to be over 100% of container (like viewport)