### PR TITLE
Add eslint-plugin-jsx-a11y and fix lint errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,8 +5,13 @@
     "es6": true,
     "node": true
   },
-  "extends": ["eslint:recommended", "plugin:react/recommended", "prettier"],
-  "plugins": ["prettier"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "prettier",
+    "plugin:jsx-a11y/recommended"
+  ],
+  "plugins": ["prettier", "jsx-a11y"],
   "rules": {
     "prettier/prettier": "error"
   },
@@ -16,6 +21,11 @@
     "allowImportExportEverywhere": "true",
     "ecmaFeatures": {
       "jsx": true
+    }
+  },
+  "settings": {
+    "react": {
+      "version": "16.3.2"
     }
   }
 }

--- a/components/AnchorHeader.js
+++ b/components/AnchorHeader.js
@@ -5,8 +5,7 @@ const AnchorHeader = ({ level, anchor, children }, { getId }) => {
   let id = getId && getId(anchor, children);
 
   return React.createElement(`h${level}`, { className: "heading" }, [
-    <a className="heading--anchor" href={`#${id}`} id={id} key="anchor" />,
-    <span className="text" key="anchor-text">
+    <span className="text" key="anchor-text" id={id}>
       {children}
     </span>,
     <a className="heading--anchor-select" href={`#${id}`} key="anchor-select">

--- a/components/Markdown.js
+++ b/components/Markdown.js
@@ -3,7 +3,7 @@ import React from "react";
 import ReactMarkdown from "react-markdown";
 import PropTypes from "prop-types";
 import AnchorHeader from "./AnchorHeader";
-import Schedule from "./Schedule";
+// import Schedule from "./Schedule";
 
 const Tip = ({ text }) => (
   <blockquote className="tip">

--- a/components/ScheduleIcon.js
+++ b/components/ScheduleIcon.js
@@ -4,7 +4,9 @@ import scheduleTypes from "./schedule-types";
 
 const ScheduleIcon = ({ type }) =>
   scheduleTypes[type] ? (
-    <abbr title={scheduleTypes[type].title}>{scheduleTypes[type].icon}</abbr>
+    <abbr className="icon-abbr" title={scheduleTypes[type].title}>
+      {scheduleTypes[type].icon}
+    </abbr>
   ) : null;
 ScheduleIcon.propTypes = {
   type: PropTypes.string,

--- a/components/ScheduleLegend.js
+++ b/components/ScheduleLegend.js
@@ -7,10 +7,10 @@ const ScheduleLegend = () => (
     <legend>Legend</legend>
 
     {Object.keys(scheduleTypes).map(type => (
-      <label key={`icon-${type}`}>
+      <div className="legend--label" key={`icon-${type}`}>
         <ScheduleIcon type={type} />
-        <span className="title">{scheduleTypes[type].title}</span>
-      </label>
+        <span className="legend--title">{scheduleTypes[type].title}</span>
+      </div>
     ))}
   </fieldset>
 );

--- a/components/SessionLink.js
+++ b/components/SessionLink.js
@@ -4,7 +4,12 @@ import { slugify } from "utils";
 
 const PrefixedSessionLink = prefix => {
   const SessionLink = ({ title }) => (
-    <a href={`/${prefix}/#${slugify(title)}`}>👩‍💻{title}</a>
+    <a href={`/${prefix}/#${slugify(title)}`}>
+      <span role="img" aria-label="Technologist">
+        👩‍💻
+      </span>
+      {title}
+    </a>
   );
   SessionLink.propTypes = {
     title: PropTypes.string,

--- a/components/Talk.js
+++ b/components/Talk.js
@@ -20,13 +20,23 @@ const Talk = ({
       <span title={type}>{TYPES[type]}</span> {title || "To be announced."}
       <span style={{ marginLeft: "1em" }}>&nbsp;</span>
       {slides && (
-        <a href={slides} style={{ fontSize: "small" }} target="_blank">
+        <a
+          href={slides}
+          style={{ fontSize: "small" }}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           Slides (PDF)
         </a>
       )}
       <span style={{ marginLeft: "1em" }}>&nbsp;</span>
       {web && (
-        <a href={web} style={{ fontSize: "small" }} target="_blank">
+        <a
+          href={web}
+          style={{ fontSize: "small" }}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           Slides (web)
         </a>
       )}

--- a/layouts/SiteBody.js
+++ b/layouts/SiteBody.js
@@ -57,7 +57,10 @@ const SiteBody = (
             <div className="grid--full">
               <div className="sponsors sponsors_gold">
                 <AnchorHeader className="sponsors--heading" level={2}>
-                  🥇 Gold Sponsors
+                  <span role="img" aria-label="First place medal">
+                    🥇
+                  </span>
+                  Gold Sponsors
                 </AnchorHeader>
                 <section className="sponsors--list">
                   <Contacts items={goldSponsors} render={Sponsor} />
@@ -68,7 +71,10 @@ const SiteBody = (
               </div>
               <div className="sponsors sponsors_silver">
                 <AnchorHeader className="sponsors--heading" level={2}>
-                  🥈 Silver Sponsors
+                  <span role="img" aria-label="Second place medal">
+                    🥈
+                  </span>
+                  Silver Sponsors
                 </AnchorHeader>
                 <section className="sponsors--list">
                   <Contacts items={silverSponsors} render={Sponsor} />
@@ -80,7 +86,10 @@ const SiteBody = (
 
               <div className="sponsors sponsors_bronze">
                 <AnchorHeader className="sponsors--heading" level={2}>
-                  🥉 Bronze Sponsors
+                  <span role="img" aria-label="Third place medal">
+                    🥉
+                  </span>
+                  Bronze Sponsors
                 </AnchorHeader>
                 <section className="sponsors--list">
                   <Contacts

--- a/package.json
+++ b/package.json
@@ -6,14 +6,12 @@
   "private": true,
   "scripts": {
     "start": "node ./antwar.bootstrap.js develop",
-    "build":
-      "rimraf ./build && node ./antwar.bootstrap.js build && npm run sitemap && npm run copy:all",
+    "build": "rimraf ./build && node ./antwar.bootstrap.js build && npm run sitemap && npm run copy:all",
     "build:netlify": "npm run build",
     "deploy": "gh-pages -d build",
     "lint": "eslint . --ignore-path .gitignore --fix",
     "test": "npm run lint",
-    "sitemap":
-      "cd build && sitemap-static --prefix=https://react-finland.fi/ > sitemap.xml",
+    "sitemap": "cd build && sitemap-static --prefix=https://react-finland.fi/ > sitemap.xml",
     "copy:all": "npm run copy:extra",
     "copy:extra": "cp -rfv assets/extra/* build",
     "styleguide": "styleguidist server",
@@ -70,6 +68,7 @@
     "css-loader": "^0.28.10",
     "eslint": "^4.18.1",
     "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.7.0",
     "extract-text-webpack-plugin": "^3.0.2",
@@ -97,6 +96,9 @@
     "webpack-merge": "^4.1.2"
   },
   "lint-staged": {
-    "*.{js,jsx,css,scss,json}": ["prettier --write", "git add"]
+    "*.{js,jsx,css,scss,json}": [
+      "prettier --write",
+      "git add"
+    ]
   }
 }

--- a/pages/for-attendees.js
+++ b/pages/for-attendees.js
@@ -69,6 +69,7 @@ const ForAttendees = () => (
         width="100%"
         height="480"
         frameBorder="0"
+        title="Google maps"
       />
       <ul>
         <li>Blue star - Paasitorni, Paasivuorenkatu 5 A</li>

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -87,13 +87,6 @@ h3 {
 
 .heading {
   @extend .grid--5col;
-  &--anchor {
-    display: block;
-    text-decoration: none;
-    top: -75px;
-    visibility: hidden;
-  }
-
   &--anchor-select {
     visibility: hidden;
     padding-left: $pu;

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -564,18 +564,16 @@ table thead th:not(:first-child) {
 
 #schedule {
   .legend {
-    label {
+    &--label {
       margin-right: 1.5em;
       display: inline-block;
-
-      .title {
-        white-space: nowrap;
-      }
     }
-
-    abbr {
-      margin-right: 0.25em;
+    &--title {
+      white-space: nowrap;
     }
+  }
+  .icon-abbr {
+    margin-right: 0.25em;
   }
 }
 


### PR DESCRIPTION
## Add eslint-plugin-jsx-a11y
* Fix: Anchors must have content and the content must be accessible by a screen reader
* Fix: Form label used in wrong purpose, refactor styles to use class-selectors
* Fix: Emojis should be wrapped in <span>, have role=img, and have an accessible description with aria-label or aria-labelledby
* Fix: Using target="_blank" without rel="noopener noreferrer" is a security risk: see https://mathiasbynens.github.io/rel-noopener
* Fix: <iframe> elements must have a unique title property
* Fix: Comment out unused import