### PR TITLE
Hide schedule emojis from accessibility tree not to be announced by screen readers

### DIFF
--- a/components/ScheduleIcon.js
+++ b/components/ScheduleIcon.js
@@ -4,7 +4,7 @@ import scheduleTypes from "./schedule-types";
 
 const ScheduleIcon = ({ type }) =>
   scheduleTypes[type] ? (
-    <abbr className="icon-abbr" title={scheduleTypes[type].title}>
+    <abbr className="icon-abbr" title={scheduleTypes[type].title} aria-hidden="true">
       {scheduleTypes[type].icon}
     </abbr>
   ) : null;


### PR DESCRIPTION
We don't need aria-label here because we already have text like “Break” or “Lunch” after the icon.